### PR TITLE
optimation for frontend

### DIFF
--- a/l1/package.json
+++ b/l1/package.json
@@ -18,6 +18,10 @@
       "require": "./dist/cjs/*.js",
       "import": "./dist/esm/*.js",
       "types": "./dist/types/*.d.ts"
+    },
+    "./artifacts/*.json": {
+      "require": "./artifacts/*.json",
+      "import": "./artifacts/*.json"
     }
   },
   "scripts": {

--- a/l1/src/features/bridge.ts
+++ b/l1/src/features/bridge.ts
@@ -64,13 +64,7 @@ export async function deployBridge(
     feeUtxo,
     feeRate
   )
-
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: psbt.toHex(),
-      options: psbt.psbtOptions(),
-    },
-  ])
+  const signedPsbt = await signer.signPsbt(psbt.toHex(), psbt.psbtOptions())
   const txPsbt = psbt.combine(ExtPsbt.fromHex(signedPsbt)).finalizeAllInputs()
 
   const tx = txPsbt.extractTransaction()
@@ -177,12 +171,7 @@ export async function finalizeL1Deposit(
     feeRate,
     estimatedVSize
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: finalizeL1Tx.toHex(),
-      options: finalizeL1Tx.psbtOptions(),
-    },
-  ])
+  const signedPsbt = await signer.signPsbt(finalizeL1Tx.toHex(), finalizeL1Tx.psbtOptions())
   const txPsbt = finalizeL1Tx.combine(ExtPsbt.fromHex(signedPsbt))
   await txPsbt.finalizeAllInputsAsync()
   const tx = txPsbt.extractTransaction()
@@ -270,12 +259,7 @@ export async function finalizeL2Deposit(
     feeRate,
     estimatedVSize
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: finalizeL2Tx.toHex(),
-      options: finalizeL2Tx.psbtOptions(),
-    },
-  ])
+  const signedPsbt = await signer.signPsbt(finalizeL2Tx.toHex(), finalizeL2Tx.psbtOptions())
   const txPsbt = finalizeL2Tx.combine(ExtPsbt.fromHex(signedPsbt))
   await txPsbt.finalizeAllInputsAsync()
   const tx = txPsbt.extractTransaction()
@@ -365,12 +349,8 @@ export async function createWithdrawalExpander(
     changeAddress,
     feeRate
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: createWithdrawalTx.toHex(),
-      options: createWithdrawalTx.psbtOptions(),
-    },
-  ])
+  
+  const signedPsbt = await signer.signPsbt(createWithdrawalTx.toHex(), createWithdrawalTx.psbtOptions())
   const txPsbt = createWithdrawalTx.combine(ExtPsbt.fromHex(signedPsbt))
   await txPsbt.finalizeAllInputsAsync()
   const tx = txPsbt.extractTransaction()

--- a/l1/src/features/deposit.ts
+++ b/l1/src/features/deposit.ts
@@ -67,12 +67,7 @@ export async function createDeposit(
     feeUtxo,
     feeRate
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: psbt.toHex(),
-      options: psbt.psbtOptions(),
-    },
-  ])
+  const signedPsbt = await signer.signPsbt(psbt.toHex(), psbt.psbtOptions())
   const txPsbt = psbt.combine(ExtPsbt.fromHex(signedPsbt)).finalizeAllInputs()
 
   const tx = txPsbt.extractTransaction()
@@ -209,12 +204,7 @@ export async function aggregateDeposit(
     feeRate,
     estimatedVSize
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: aggregateTx.toHex(),
-      options: aggregateTx.psbtOptions(),
-    },
-  ])
+  const signedPsbt = await signer.signPsbt(aggregateTx.toHex(), aggregateTx.psbtOptions())
   const txPsbt = aggregateTx.combine(ExtPsbt.fromHex(signedPsbt))
   await txPsbt.finalizeAllInputsAsync()
   const tx = txPsbt.extractTransaction()

--- a/l1/src/features/withdraw.ts
+++ b/l1/src/features/withdraw.ts
@@ -101,12 +101,7 @@ export async function expandWithdrawal(
     changeAddress,
     feeRate
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: psbt.toHex(),
-      options: psbt.psbtOptions(),
-    },
-  ])
+  const signedPsbt = await signer.signPsbt(psbt.toHex(), psbt.psbtOptions())
   const txPsbt = psbt.combine(ExtPsbt.fromHex(signedPsbt))
   await txPsbt.finalizeAllInputsAsync()
   const tx = txPsbt.extractTransaction()
@@ -298,12 +293,8 @@ export async function distributeWithdrawals(
     changeAddress,
     feeRate
   )
-  const [signedPsbt] = await signer.signPsbts([
-    {
-      psbtHex: psbt.toHex(),
-      options: psbt.psbtOptions(),
-    },
-  ])
+  
+  const signedPsbt = await signer.signPsbt(psbt.toHex(), psbt.psbtOptions())
   const txPsbt = psbt.combine(ExtPsbt.fromHex(signedPsbt))
   await txPsbt.finalizeAllInputsAsync()
   const tx = txPsbt.extractTransaction()

--- a/l1/src/index.ts
+++ b/l1/src/index.ts
@@ -1,4 +1,6 @@
-
+export {Bridge} from './contracts/bridge'
+export {DepositAggregator} from './contracts/depositAggregator'
+export {WithdrawalExpander} from './contracts/withdrawalExpander'
 
 
 export * from './features/bridge'
@@ -51,8 +53,11 @@ export {MempoolUtxoProvider} from './providers/mempoolUtxoProvider'
 export {RPCChainProvider} from './providers/rpcChainProvider'
 export {RPCUtxoProvider} from './providers/rpcUtxoProvider'
 export { TestUtxoProvider, TestChainProvider } from './providers/testProvider'
+export { NoBroadcastingChainProvider } from './providers/noBroadcastingChainProvider'
 
 export * from './lib/signer'
 export {DefaultSigner} from './signers/defaultSigner'
+export {UnisatSigner} from './signers/unisatSigner'
+export {DummySigner} from './signers/dummySigner'
 export * from './util/merkleUtils';
 export * as btcRpc from './util/rpc'

--- a/l1/src/lib/extPsbt.ts
+++ b/l1/src/lib/extPsbt.ts
@@ -325,7 +325,7 @@ export class ExtPsbt extends Psbt {
         script: btc.Script.fromAddress(
           validteSupportedAddress(address)
         ).toBuffer(),
-        value: BigInt(changeAmount),
+        value: BigInt(Math.ceil(changeAmount)),
       })
       const index = this.txOutputs.length - 1
       this.changeOutputIndex = index

--- a/l1/src/providers/noBroadcastingChainProvider.ts
+++ b/l1/src/providers/noBroadcastingChainProvider.ts
@@ -1,0 +1,16 @@
+import { ChainProvider } from "../lib/provider";
+import { Transaction } from "@scrypt-inc/bitcoinjs-lib";
+
+export class NoBroadcastingChainProvider implements ChainProvider {
+    constructor(private readonly baseProvider: ChainProvider) {}
+    async getRawTransaction(txId: string): Promise<string> {
+        return this.baseProvider.getRawTransaction(txId)
+    }
+    async getConfirmations(txId: string): Promise<number> {
+        return this.baseProvider.getConfirmations(txId)
+    }
+    async broadcast(txHex: string): Promise<string> {
+        const txId = Transaction.fromHex(txHex).getId()
+        return txId
+    }
+}

--- a/l1/src/signers/dummySigner.ts
+++ b/l1/src/signers/dummySigner.ts
@@ -1,0 +1,37 @@
+import { PSBTOptions, Signer } from "../lib/signer";
+
+
+export class DummySigner implements Signer {
+
+    private sigReqs: { psbtHex: string, options?: PSBTOptions }[] = [];
+    static DUMMY_SIG = '70736274ff0100bc0200000001d9036d9f708cb10e483bf3cd76aa614e1e9e6d9ea547d307639ca7a32e5778ee0000000000ffffffff0300000000000000002a6a2802d889448e2ce40fa6874e0bc0bd6156d535a1c9866fd9163be5756e5695493b9b020000000000009b0200000000000022512040a1a612f896c0a9bab8908f7437bad67ca3e3e6c0fc53fa547325973f3534510717676ffebe0000225120e157c92fbb3072bb22122656ec90f98206a24691f57a8af4a626a51b39c4aec4000000000001012b0020676ffebe0000225120e157c92fbb3072bb22122656ec90f98206a24691f57a8af4a626a51b39c4aec4011340ee5230d6b72af262e677c1fe9c483705607e043ce29dc69f64f4a0b7385ceedb337c976be2cdf4641268f9e08e8a1d44cffc7f6eca67b9c3f241a293093e2562011720bfac5406925f9fa00194aa5fd093f60775d90475dcf88c24359eddd385b398a800000000'
+
+    constructor(private readonly address: string) {
+    }
+
+    async getAddress(): Promise<string> {
+        return this.address
+    }
+
+    async getPublicKey(): Promise<string> {
+        // 03bfac5406925f9fa00194aa5fd093f60775d90475dcf88c24359eddd385b398a8
+        return 'dummy'
+    }
+
+    async signPsbt(psbtHex: string, options?: PSBTOptions): Promise<string> {
+        this.sigReqs.push({ psbtHex, options })
+        return DummySigner.DUMMY_SIG
+    }
+
+    async signPsbts(reqs: { psbtHex: string, options?: PSBTOptions }[]): Promise<string[]> {
+        this.sigReqs.push(...reqs)
+        return reqs.map(_ => DummySigner.DUMMY_SIG)
+    }
+
+    popSigReqs(): { psbtHex: string, options?: PSBTOptions }[] {
+        const reqs = this.sigReqs
+        this.sigReqs = []
+        return reqs
+    }
+}
+

--- a/l1/src/signers/unisatSigner.ts
+++ b/l1/src/signers/unisatSigner.ts
@@ -1,0 +1,55 @@
+import { PSBTOptions, Signer } from '../lib/signer';
+
+interface Window {
+    X: number;
+    scrollY: number;
+  }
+  
+declare const window: Window & typeof globalThis;
+
+type HexString = string;
+
+export interface UnisatAPI {
+	getAccounts: () => Promise<string[]>
+	requestAccounts: () => Promise<string[]>
+	getPublicKey: () => Promise<string>
+    signPsbt(psbtHex: HexString, options?: PSBTOptions): Promise<HexString>;
+    signPsbts(psbtHexs: HexString[], options?: PSBTOptions[]): Promise<HexString[]>;
+}
+
+export class UnisatSigner implements Signer {
+    private _unisat: UnisatAPI;
+
+    constructor(unisat: UnisatAPI) {
+        this._unisat = unisat
+    }
+
+    getUnisatAPI(): UnisatAPI {
+        const unisat = this._unisat || window['unisat'];
+        if(typeof unisat === 'undefined') {
+			throw new Error('unisat not install!');
+		}
+
+        return unisat;
+    }
+
+    async getAddress(): Promise<string> {
+        const accounts = await this.getUnisatAPI().getAccounts();
+        return accounts[0]
+    }
+
+    async getPublicKey(): Promise<string> {
+        return this.getUnisatAPI().getPublicKey();
+    }
+
+    async signPsbt(psbtHex: string, options?: PSBTOptions): Promise<string> {
+        return this.getUnisatAPI().signPsbt(psbtHex, options)
+    }
+
+    signPsbts(
+        reqs: { psbtHex: string; options?: PSBTOptions }[],
+    ): Promise<string[]> {
+		const options: PSBTOptions[] = reqs.filter(option => typeof option === 'object').map(req => (req.options as PSBTOptions));
+		return this.getUnisatAPI().signPsbts(reqs.map(req => req.psbtHex), options);
+    }
+}


### PR DESCRIPTION
1. add `unisatSigner` and `dummySigner` to support unisat wallet and backend transaction construction
2. add `noBroadcastingChainProvider` to support backend transaction construction
3. use `signPsbt` instead of `signPsbts` to give user better signing experience
4. export l1 artifacts to support load artifact in browser