### PR TITLE
fix: dashboard expansion tree

### DIFF
--- a/dashboard/src/components/StatusChip/index.tsx
+++ b/dashboard/src/components/StatusChip/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import {useMemo} from 'react';
-import {useTheme} from 'styled-components';
 
-import {DepositStatus, StatusType, WithdrawalStatus} from '@/types';
+import {DepositStatus, WithdrawalStatus} from '@/types';
 import {getDepositStatusType, getWithdrawalStatusType} from '@/utils/format';
 
 import {StyledStatusChip} from './styled';
@@ -19,8 +18,6 @@ type StatusChipProps =
     };
 
 export const StatusChip: React.FC<StatusChipProps> = (props) => {
-  const theme = useTheme();
-
   const status = useMemo(() => {
     if (props.type === 'deposit') {
       return getDepositStatusType(props.status);
@@ -29,15 +26,5 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
     return getWithdrawalStatusType(props.status);
   }, [props.type, props.status]);
 
-  const color = useMemo(() => {
-    const colors = {
-      pending: theme.colors.warning,
-      success: theme.colors.success,
-      error: theme.colors.error,
-    } satisfies Record<StatusType, string>;
-
-    return colors[status];
-  }, [status, theme.colors]);
-
-  return <StyledStatusChip color={color}>{props.status}</StyledStatusChip>;
+  return <StyledStatusChip $status={status}>{props.status}</StyledStatusChip>;
 };

--- a/dashboard/src/components/StatusChip/styled.ts
+++ b/dashboard/src/components/StatusChip/styled.ts
@@ -1,16 +1,33 @@
 import Color from 'color';
-import styled from 'styled-components';
+import styled, {css} from 'styled-components';
+
+import {StatusType} from '@/types';
 
 import {Text} from '../Text';
+
+const darkenColor = (color: string, ratio = 0.5) => Color(color).darken(ratio).string();
+const alphaColor = (color: string, value = 0.15) => Color(color).alpha(value).string();
 
 export const StyledStatusChip = styled(Text.Title).attrs((props) => ({
   ...props,
   $fontSize: 12,
-}))<{color: string}>`
+}))<{$status: StatusType}>`
   display: inline-block;
   padding: ${({theme}) => `${theme.spacings.xsmall / 2}px ${theme.spacings.xsmall}px`};
-  color: ${({theme, color}) => (theme.dark ? color : Color(color).darken(0.5).string())};
-  background-color: ${({color}) => Color(color).alpha(0.15).string()};
-  border: 1px solid ${({theme, color}) => (theme.dark ? Color(color).darken(0.5).string() : color)};
+  color: ${({theme, $status}) => (theme.dark ? theme.colors[$status] : darkenColor(theme.colors[$status]))};
+  background-color: ${({theme, $status}) => alphaColor(theme.colors[$status])};
+  border: 1px solid ${({theme, $status}) => (theme.dark ? darkenColor(theme.colors[$status]) : theme.colors[$status])};
   border-radius: 4px;
+  will-change: opacity, box-shadow, text-shadow;
+
+  ${({theme, $status}) =>
+    $status === 'pending'
+      ? css`
+          animation: ${theme.animations.pulse(
+              theme.colors[$status],
+              alphaColor(darkenColor(theme.colors[$status]), 0.6),
+            )}
+            2s ${theme.transitions.timing.inOut} infinite alternate;
+        `
+      : ''}
 `;

--- a/dashboard/src/components/TransactionStatus/index.ts
+++ b/dashboard/src/components/TransactionStatus/index.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import styled from 'styled-components';
+import Color from 'color';
+import styled, {css} from 'styled-components';
 
 import {StatusType} from '../../types';
 
@@ -8,14 +9,15 @@ export const TransactionStatus = styled.div<{$status: StatusType; $size?: number
   display: inline-block;
   width: ${({$size = 12}) => `${$size}px`};
   height: ${({$size = 12}) => `${$size}px`};
-  background-color: ${({theme, $status}) => {
-    const colors = {
-      success: theme.colors.success,
-      error: theme.colors.error,
-      pending: theme.colors.warning,
-    } satisfies Record<StatusType, string>;
-
-    return colors[$status];
-  }};
   border-radius: 50%;
+  background-color: ${({theme, $status}) => Color(theme.colors[$status]).string()};
+  will-change: opacity, box-shadow;
+
+  ${({theme, $status}) =>
+    $status === 'pending'
+      ? css`
+          animation: ${theme.animations.pulse(theme.colors[$status])} 2s ${theme.transitions.timing.inOut} infinite
+            alternate;
+        `
+      : ''}
 `;

--- a/dashboard/src/theme/animations.ts
+++ b/dashboard/src/theme/animations.ts
@@ -1,0 +1,14 @@
+import {keyframes} from 'styled-components';
+
+export const pulse = (color: string, textColor?: string) => keyframes`
+  from {
+    opacity: 1;
+    box-shadow: 0 0 3px 1px ${color};
+    ${textColor ? `text-shadow: 0 0 4px ${color};` : ''}
+  }
+  to {
+    opacity: 0.75;
+    box-shadow: 0 0 0 0 ${color};
+    ${textColor ? `text-shadow: 0 0 0 ${color};` : ''}
+  }
+`;

--- a/dashboard/src/theme/colors.ts
+++ b/dashboard/src/theme/colors.ts
@@ -31,10 +31,10 @@ export const darkThemeColors = {
 
   border: '#343434',
 
+  // Status colors
   success: '#55E065',
   error: '#FF495C',
-  info: '#00C3F9',
-  warning: '#FFC43A',
+  pending: '#FFC43A',
 };
 
 export const lightThemeColors = {
@@ -57,8 +57,8 @@ export const lightThemeColors = {
 
   border: '#ebebeb',
 
+  // Status colors
   success: '#55E065',
   error: '#FF495C',
-  info: '#00C3F9',
-  warning: '#FFC43A',
+  pending: '#FFC43A',
 };

--- a/dashboard/src/theme/index.tsx
+++ b/dashboard/src/theme/index.tsx
@@ -5,6 +5,7 @@ import {ThemeProvider as SCThemeProvider} from 'styled-components';
 
 import {ToggleThemeContext} from '@/hooks/useToggleTheme';
 
+import * as animations from './animations';
 import {darkThemeColors, lightThemeColors} from './colors';
 
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
@@ -69,6 +70,7 @@ const misc = {
   },
   transitions,
   spacings,
+  animations,
 };
 
 export function getTheme(theme: 'dark' | 'light') {

--- a/dashboard/src/types/state.ts
+++ b/dashboard/src/types/state.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line no-restricted-syntax
 export type * from 'operator';
 
-import {DepositBatch, L1TxStatus, L2TxStatus, OperatorState, WithdrawalBatch} from 'operator';
+import {DepositBatch, L1Tx, L1TxStatus, L2TxStatus, OperatorState, WithdrawalBatch} from 'operator';
 
 export type TxStatus = L1TxStatus['status'] | L2TxStatus['status'];
 
@@ -19,3 +19,13 @@ export type StateWithDate = {
 
 export type WithdrawalExpansionNode = (WithdrawalBatch & {status: 'EXPANDED'})['expansionTree'];
 export type WithdrawalExpansionInnerNode = WithdrawalExpansionNode & {type: 'INNER'};
+export type WithdrawalExpansionLeafNode = WithdrawalExpansionNode & {type: 'LEAF'};
+
+export type AccumulatedExpansionTx =
+  | (L1Tx & {
+      nodeType: WithdrawalExpansionNode['type'];
+      nodeHash: WithdrawalExpansionNode['hash'];
+      total?: WithdrawalExpansionLeafNode['total'];
+      address?: WithdrawalExpansionLeafNode['l1Address'];
+    })
+  | null;

--- a/operator/src/poc.ts
+++ b/operator/src/poc.ts
@@ -1,7 +1,7 @@
 import { RpcProvider } from 'starknet';
 import { importAddressesIntoNode } from './l1/prepare';
 import { closeWithdrawalBatch, submitDepositsToL2 } from './l2/contracts';
-import { applyChange, BridgeEnvironment, OperatorState } from './state';
+import { applyChange, BridgeEnvironment, L1TxId, OperatorState } from './state';
 import { setupOperator } from './operator';
 import {
   deposits,
@@ -143,7 +143,7 @@ async function pocOperator() {
       ),
   };
 
-  const l1TxStatus = (tx) =>
+  const l1TxStatus = (tx: L1TxId) =>
     l1TransactionStatus(config.l1.createL1Provider(), tx);
 
   const operator = setupOperator(


### PR DESCRIPTION
Added pulse animation to the status chip & status indicators for pending status.
![image](https://github.com/user-attachments/assets/aadd6af4-40a2-4830-adcc-be174d614520)

Fixed the issue with expansion tree.
![image](https://github.com/user-attachments/assets/bba5186f-e3ef-47c0-a77d-cc3dc3a978e6)

Fixed a type error in operator that was causing the CI to fail.
Optionally, we can add a CI workflow for operator too.