### PR TITLE
remove bigger font leaf index

### DIFF
--- a/dashboard/src/app/index/StateHeader/index.tsx
+++ b/dashboard/src/app/index/StateHeader/index.tsx
@@ -76,7 +76,7 @@ export const StateHeader: React.FC<{state: OperatorState}> = ({state}) => {
 
                 return (
                   <Row key={leaf} $alignItems="center" $gap="xsmall" $flex={1}>
-                    <Value $fontSize={18}>{index + 1}:</Value>
+                    <Value>{index + 1}:</Value>
 
                     <Value>{shortenHex(leaf, 12)}</Value>
                   </Row>


### PR DESCRIPTION
Removed the `$fontSize={18}` prop from leaf indexes to make it same size as the value